### PR TITLE
Set empty default for vip_address

### DIFF
--- a/tasks/generate.yml
+++ b/tasks/generate.yml
@@ -69,7 +69,7 @@
 
 - name: Combine virtual and default maps
   set_fact:
-    network_allocations: "{{ vip_addresses | combine(ip_map) }}"
+    network_allocations: "{{ vip_addresses | default({}) | combine(ip_map) }}"
 
 - debug:
     msg: "{{ network_allocations }}"


### PR DESCRIPTION
Fixes `'|combine expects dictionaries, got Undefined'` issue when vip_addresses is not set.
